### PR TITLE
Minimal Web API template

### DIFF
--- a/Auth0Templates.csproj
+++ b/Auth0Templates.csproj
@@ -41,6 +41,7 @@
       <Copy SourceFiles="@(CliWrapperFiles)" DestinationFolder="templates\Auth0.BlazorWebAssembly\Server\registration" SkipUnchangedFiles="false" />
       <Copy SourceFiles="@(CliWrapperFiles)" DestinationFolder="templates\Auth0.Mvc\registration" SkipUnchangedFiles="false" />
       <Copy SourceFiles="@(CliWrapperFiles)" DestinationFolder="templates\Auth0.WebAPI\registration" SkipUnchangedFiles="false" />
+      <Copy SourceFiles="@(CliWrapperFiles)" DestinationFolder="templates\Auth0.MinimalWebAPI\registration" SkipUnchangedFiles="false" />
     </Target>
 
 </Project>

--- a/docs/auth0webapi.md
+++ b/docs/auth0webapi.md
@@ -22,8 +22,10 @@ In addition to the usual options for the `dotnet new` command, the following tem
   The API identifier (audience) as defined in your Auth0 dashboard. The default value is `https://your-api-id.com`
 - `-f` or `--framework`<br>
   Defines the target framework to use for the .NET project. Currently, the only possible value is `net7.0`, which is also the default value.
-- `--no-openaPI`<br>
+- `--no-openapi`<br>
   It prevents OpenAPI documentation generation (`true`). The default value is `false`.
+- `--minimal`
+  It creates a project that uses the [ASP.NET Core minimal API](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis). Default is `false`.
 
 Example:
 

--- a/templates/Auth0.MinimalWebAPI/Auth0WebAPI.csproj
+++ b/templates/Auth0.MinimalWebAPI/Auth0WebAPI.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/templates/Auth0.MinimalWebAPI/Program.cs
+++ b/templates/Auth0.MinimalWebAPI/Program.cs
@@ -1,0 +1,48 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication().AddJwtBearer();
+builder.Services.AddAuthorization();
+
+#if (!removeOpenAPI)
+builder.Services.AddSwaggerService();
+#endif
+
+var app = builder.Build();
+
+#if (!removeOpenAPI)
+if (app.Environment.IsDevelopment())
+{
+  app.UseSwagger();
+  app.UseSwaggerUI();
+}
+#endif
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast")
+.RequireAuthorization()
+.WithOpenApi();
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/templates/Auth0.MinimalWebAPI/Properties/launchSettings.json
+++ b/templates/Auth0.MinimalWebAPI/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "Auth0MinimalWebAPI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/Auth0.MinimalWebAPI/SwaggerExtensions.cs
+++ b/templates/Auth0.MinimalWebAPI/SwaggerExtensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.OpenApi.Models;
+
+public static class SwaggerExtensions
+{
+  public static IServiceCollection AddSwaggerService(this IServiceCollection services)
+  {
+    // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+    services.AddEndpointsApiExplorer();
+    services.AddSwaggerGen(options =>
+    {
+      options.SwaggerDoc("v1", new OpenApiInfo { 
+        Title = "Auth0WebAPI",
+        Description = "Learn how to protect your .NET applications with Auth0",
+        Contact = new OpenApiContact {
+          Name = ".NET Identity with Auth0",
+          Url = new Uri("https://auth0.com/resources/ebooks/net-identity-with-auth0?utm_source=auth0_dotnet_template&utm_medium=sc&utm_campaign=webapi_dotnet_ebook")
+        },
+        Version = "v1.0.0" });
+
+      var securitySchema = new OpenApiSecurityScheme
+      {
+        Description = "Using the Authorization header with the Bearer scheme.",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        Reference = new OpenApiReference
+        {
+          Type = ReferenceType.SecurityScheme,
+          Id = "Bearer"
+        }
+      };
+
+      options.AddSecurityDefinition("Bearer", securitySchema);
+
+      options.AddSecurityRequirement(new OpenApiSecurityRequirement
+              {
+                  { securitySchema, new[] { "Bearer" } }
+              });
+    });
+
+    return services;
+  }
+}

--- a/templates/Auth0.MinimalWebAPI/appsettings.Development.json
+++ b/templates/Auth0.MinimalWebAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/templates/Auth0.MinimalWebAPI/appsettings.json
+++ b/templates/Auth0.MinimalWebAPI/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "Authority": "https://{DOMAIN}",
+        "ValidAudiences": [ "{AUDIENCE}" ],
+        "ValidIssuer": "{DOMAIN}"
+      }
+    }
+  }
+}

--- a/templates/Auth0.MinimalWebAPI/registration/config.json
+++ b/templates/Auth0.MinimalWebAPI/registration/config.json
@@ -1,0 +1,8 @@
+{
+  "AppName": "Auth0WebAPI",
+  "AppDescription": "ASP.NET Core Minimal Web API application created and registered via Auth0 Templates for .NET",
+  "AppType": "api",
+  "Callbacks": "",
+  "LogoutUrls": "",
+  "AppSettingsFiles": ["./appsettings.json"]
+}

--- a/templates/Auth0.WebAPI/.template.config/template.json
+++ b/templates/Auth0.WebAPI/.template.config/template.json
@@ -58,6 +58,12 @@
       "type": "computed",
       "value": "(DisableOpenAPI || !EnableOpenAPI)"
     },
+    "minimal": {
+      "type": "parameter",
+      "dataType":"bool",
+      "defaultValue": "false",
+      "description": "Create a project that uses the ASP.NET Core minimal API."
+    },
     "autoregister": {
       "type": "computed",
       "value": "(domain == \"yourdomain.auth0.com\" && audience == \"https://your-api-id.com\")"
@@ -152,17 +158,33 @@
   },
   "sources": [
     {
+        "condition": "(!minimal)",
+        "source": "./",
         "modifiers": [
             {
                 "condition": "(removeOpenAPI)",
-                "exclude": [ "Swagger/**/*" ]
+                "exclude": [ "SwaggerExtensions.cs" ]
             },
             {
               "condition": "(!autoregister)",
               "exclude": [ "registration/**/*" ]
           }
         ]
-    }
+    },
+    {
+      "condition": "(minimal)",
+      "source": "../Auth0.MinimalWebAPI/",
+      "modifiers": [
+          {
+              "condition": "(removeOpenAPI)",
+              "exclude": [ "SwaggerExtensions.cs" ]
+          },
+          {
+            "condition": "(!autoregister)",
+            "exclude": [ "registration/**/*" ]
+        }
+      ]
+  }
   ],
   "postActions": [{
     "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",

--- a/templates/Auth0.WebAPI/Program.cs
+++ b/templates/Auth0.WebAPI/Program.cs
@@ -24,6 +24,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapControllers();
+app.MapControllers());
 
 app.Run();

--- a/templates/Auth0.WebAPI/Program.cs
+++ b/templates/Auth0.WebAPI/Program.cs
@@ -24,6 +24,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapControllers());
+app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
This PR adds the minimal Web API templates as a subtemplate of Web API.
It follows the standard approach based on the `--minimal` option:

`dotnet new auth0webapi -o MyMinAPI --minimal --domain mydomain-auth0.com --audience https://myminapi.com`