### PR TITLE
Support for .NET 8

### DIFF
--- a/templates/Auth0.BlazorServer/Auth0BlazorServer.csproj
+++ b/templates/Auth0.BlazorServer/Auth0BlazorServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.0.4" />
+    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/Auth0.BlazorWebAssembly/Client/Auth0BlazorWasm.Client.csproj
+++ b/templates/Auth0.BlazorWebAssembly/Client/Auth0BlazorWasm.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.13" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
   </ItemGroup>
 

--- a/templates/Auth0.BlazorWebAssembly/Server/Auth0BlazorWasm.Server.csproj
+++ b/templates/Auth0.BlazorWebAssembly/Server/Auth0BlazorWasm.Server.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Auth0.BlazorWebAssembly/Shared/Auth0BlazorWasm.Shared.csproj
+++ b/templates/Auth0.BlazorWebAssembly/Shared/Auth0BlazorWasm.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/templates/Auth0.MinimalWebAPI/Auth0WebAPI.csproj
+++ b/templates/Auth0.MinimalWebAPI/Auth0WebAPI.csproj
@@ -4,12 +4,16 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization Condition="'$(Framework)' == 'net8.0'">true</InvariantGlobalization>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.11" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" Condition="'$(Framework)' == 'net8.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13"  Condition="'$(removeOpenAPI)' == 'False'" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0"  Condition="'$(removeOpenAPI)' == 'False'" Condition="'$(Framework)' == 'net8.0'"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"  Condition="'$(removeOpenAPI)' == 'False'"/>
   </ItemGroup>
 
 </Project>

--- a/templates/Auth0.Mvc/.template.config/template.json
+++ b/templates/Auth0.Mvc/.template.config/template.json
@@ -37,9 +37,13 @@
         {
           "choice": "net7.0",
           "description": "Target .NET 7"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8"
         }
       ],
-      "defaultValue": "net7.0",
+      "defaultValue": "net8.0",
       "replaces": "net7.0"
     },
     "autoregister": {

--- a/templates/Auth0.Mvc/Auth0Mvc.csproj
+++ b/templates/Auth0.Mvc/Auth0Mvc.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.0.4" />
+    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/templates/Auth0.WebAPI/.template.config/template.json
+++ b/templates/Auth0.WebAPI/.template.config/template.json
@@ -37,9 +37,13 @@
         {
           "choice": "net7.0",
           "description": "Target .NET 7"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8"
         }
       ],
-      "defaultValue": "net7.0",
+      "defaultValue": "net8.0",
       "replaces": "net7.0"
     },
     "DisableOpenAPI": {

--- a/templates/Auth0.WebAPI/Auth0WebAPI.csproj
+++ b/templates/Auth0.WebAPI/Auth0WebAPI.csproj
@@ -4,13 +4,16 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization Condition="'$(Framework)' == 'net8.0'">true</InvariantGlobalization>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0"  Condition="'$(removeOpenAPI)' == 'False'"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"  Condition="'$(removeOpenAPI)' == 'False'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" Condition="'$(Framework)' == 'net8.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13"  Condition="'$(removeOpenAPI)' == 'False'" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0"  Condition="'$(removeOpenAPI)' == 'False'" Condition="'$(Framework)' == 'net8.0'"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"  Condition="'$(removeOpenAPI)' == 'False'"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

This PR adds .NET 8 as the target for the following templates:
- Auth0 ASP.NET Core Web API
- Auth0 ASP.NET Core Web App

The Blazor Server and WebAssembly templates are only targeted to .NET 7 as it happens in the current (ver. 8) `dotnet new` command

Close #13