### PR TITLE
Patch shebang

### DIFF
--- a/Auth0Templates.csproj
+++ b/Auth0Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.1.1</PackageVersion>
     <PackageId>Auth0.Templates</PackageId>
     <Title>Auth0 Templates for .NET</Title>
     <Authors>Auth0</Authors>

--- a/cli-wrapper/CliWrapper.cs
+++ b/cli-wrapper/CliWrapper.cs
@@ -7,7 +7,14 @@ public class CliWrapper
   ConfigData configData = new ConfigData();
 
   public CliWrapper()
-  { }
+  {
+    string templateConfigurationFilePath = $@"{Path.Combine(System.AppContext.BaseDirectory, "config.json")}";
+    string text = File.ReadAllText(templateConfigurationFilePath);
+
+    configData = JsonSerializer.Deserialize<ConfigData>(text);
+
+    Displayer.Verbose = configData.Verbose;
+  }
 
   public async Task<bool> IsAuth0CliInstalled()
   {
@@ -38,15 +45,15 @@ public class CliWrapper
 
     try
     {
-      string templateConfigurationFilePath = $@"{Path.Combine(System.AppContext.BaseDirectory, "config.json")}";
+      // string templateConfigurationFilePath = $@"{Path.Combine(System.AppContext.BaseDirectory, "config.json")}";
 
-      Displayer.DisplayVerbose($@"Reading template configuration from {templateConfigurationFilePath}");
+      // Displayer.DisplayVerbose($@"Reading template configuration from {templateConfigurationFilePath}");
 
-      string text = File.ReadAllText(templateConfigurationFilePath);
+      // string text = File.ReadAllText(templateConfigurationFilePath);
 
-      Displayer.DisplayTemplateConfiguration(text);
+      // Displayer.DisplayTemplateConfiguration(text);
 
-      configData = JsonSerializer.Deserialize<ConfigData>(text);
+      // configData = JsonSerializer.Deserialize<ConfigData>(text);
 
       if (configData.AppType.ToLower() == "api")
       {

--- a/cli-wrapper/ConfigData.cs
+++ b/cli-wrapper/ConfigData.cs
@@ -6,4 +6,6 @@
   public string? Callbacks { get; set; }
   public string? LogoutUrls { get; set; }
   public string[]? AppSettingsFiles {get; set;}
+
+  public bool Verbose {get; set;}
 }

--- a/cli-wrapper/README.md
+++ b/cli-wrapper/README.md
@@ -21,7 +21,8 @@ In order to enable a template to automatic registration via the CLI Wrapper, app
     "AppType": "regular",
     "Callbacks": "https://localhost:5001/callback",
     "LogoutUrls": "https://localhost:5001/",
-    "AppSettingsFiles": ["./appsettings.json"]
+    "AppSettingsFiles": ["./appsettings.json"],
+    "Verbose": false
   }
   ```
 
@@ -32,6 +33,7 @@ In order to enable a template to automatic registration via the CLI Wrapper, app
   - `AppType` must contain the specific application type for the current project (see [type flag](https://auth0.github.io/auth0-cli/auth0_apps_create.html#flags) required by the `auth0 apps create` command of the Auth0 CLI). Its value is `api` for API templates.
   - `Callbacks` and `LogoutUrls` must use the same ports as in the templates (see `Properties/launchSettings.json`). Set these properties to empty strings for API templates.
   - `AppSettingsFiles` must point to the project's configuration files to update after registration
+  - `Verbose` is a boolean setting that enables a verbose onscreen log for diagnostic purposes.
 
 - Add the following `postAction` in the `template.config` file of the template:
   ```json

--- a/templates/Auth0.BlazorServer/register-with-auth0.cmd
+++ b/templates/Auth0.BlazorServer/register-with-auth0.cmd
@@ -1,2 +1,6 @@
+rem #if (OS != "Windows_NT")
 #!/bin/sh
 dotnet ./registration/cli-wrapper.dll
+rem #else
+dotnet registration/cli-wrapper.dll
+rem #endif

--- a/templates/Auth0.BlazorServer/registration/config.json
+++ b/templates/Auth0.BlazorServer/registration/config.json
@@ -4,5 +4,6 @@
   "AppType": "regular",
   "Callbacks": "https://localhost:5001/callback",
   "LogoutUrls": "https://localhost:5001/",
-  "AppSettingsFiles": ["./appsettings.json"]
+  "AppSettingsFiles": ["./appsettings.json"],
+  "Verbose": false
 }

--- a/templates/Auth0.BlazorWebAssembly/Client/registration/config.json
+++ b/templates/Auth0.BlazorWebAssembly/Client/registration/config.json
@@ -4,5 +4,6 @@
   "AppType": "spa",
   "Callbacks": "https://localhost:5001/authentication/login-callback",
   "LogoutUrls": "https://localhost:5001",
-  "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"]
+  "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"],
+  "Verbose": false
 }

--- a/templates/Auth0.BlazorWebAssembly/Server/registration/config.json
+++ b/templates/Auth0.BlazorWebAssembly/Server/registration/config.json
@@ -4,5 +4,6 @@
   "AppType": "api",
   "Callbacks": "",
   "LogoutUrls": "",
-  "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"]
+  "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"],
+  "Verbose": false
 }

--- a/templates/Auth0.BlazorWebAssembly/register-with-auth0.cmd
+++ b/templates/Auth0.BlazorWebAssembly/register-with-auth0.cmd
@@ -1,3 +1,8 @@
+rem #if (OS != "Windows_NT")
 #!/bin/sh
 dotnet ./Client/registration/cli-wrapper.dll
 dotnet ./Server/registration/cli-wrapper.dll
+rem #else
+dotnet Client/registration/cli-wrapper.dll
+dotnet Server/registration/cli-wrapper.dll
+rem #endif

--- a/templates/Auth0.MinimalWebAPI/register-with-auth0.cmd
+++ b/templates/Auth0.MinimalWebAPI/register-with-auth0.cmd
@@ -1,2 +1,6 @@
+rem #if (OS != "Windows_NT")
 #!/bin/sh
 dotnet ./registration/cli-wrapper.dll
+rem #else
+dotnet registration/cli-wrapper.dll
+rem #endif

--- a/templates/Auth0.Mvc/register-with-auth0.cmd
+++ b/templates/Auth0.Mvc/register-with-auth0.cmd
@@ -1,2 +1,6 @@
+rem #if (OS != "Windows_NT")
 #!/bin/sh
 dotnet ./registration/cli-wrapper.dll
+rem #else
+dotnet registration/cli-wrapper.dll
+rem #endif

--- a/templates/Auth0.Mvc/registration/config.json
+++ b/templates/Auth0.Mvc/registration/config.json
@@ -4,5 +4,6 @@
   "AppType": "regular",
   "Callbacks": "https://localhost:5001/callback",
   "LogoutUrls": "https://localhost:5001/",
-  "AppSettingsFiles": ["./appsettings.json"]
+  "AppSettingsFiles": ["./appsettings.json"],
+  "Verbose": false
 }

--- a/templates/Auth0.WebAPI/register-with-auth0.cmd
+++ b/templates/Auth0.WebAPI/register-with-auth0.cmd
@@ -1,2 +1,6 @@
+rem #if (OS != "Windows_NT")
 #!/bin/sh
 dotnet ./registration/cli-wrapper.dll
+rem #else
+dotnet registration/cli-wrapper.dll
+rem #endif

--- a/templates/Auth0.WebAPI/registration/config.json
+++ b/templates/Auth0.WebAPI/registration/config.json
@@ -4,5 +4,6 @@
   "AppType": "api",
   "Callbacks": "",
   "LogoutUrls": "",
-  "AppSettingsFiles": ["./appsettings.json"]
+  "AppSettingsFiles": ["./appsettings.json"],
+  "Verbose": false
 }


### PR DESCRIPTION
This PR adds the following:
- It fixes a bug on Windows due to the presence of the shebang (`!#`) in the registering script
- Add the `Verbose` setting to the CLI wrapper