### PR TITLE
[ADD] .NET 8 support for the Auth0 Blazor WebAssembly template

### DIFF
--- a/templates/Auth0.BlazorWebAssembly/.template.config/template.json
+++ b/templates/Auth0.BlazorWebAssembly/.template.config/template.json
@@ -49,9 +49,13 @@
         {
           "choice": "net7.0",
           "description": "Target .NET 7"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8"
         }
       ],
-      "defaultValue": "net7.0",
+      "defaultValue": "net8.0",
       "replaces": "net7.0"
     },
     "autoregister": {

--- a/templates/Auth0.BlazorWebAssembly/Client/Auth0BlazorWasm.Client.csproj
+++ b/templates/Auth0.BlazorWebAssembly/Client/Auth0BlazorWasm.Client.csproj
@@ -7,10 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.13" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.13" PrivateAssets="all" Condition="'$(Framework)' == 'net7.0'"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" Condition="'$(Framework)' == 'net7.0'"/>
+
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" Condition="'$(Framework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" Condition="'$(Framework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.1" PrivateAssets="all" Condition="'$(Framework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" Condition="'$(Framework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Auth0.BlazorWebAssembly/Server/Auth0BlazorWasm.Server.csproj
+++ b/templates/Auth0.BlazorWebAssembly/Server/Auth0BlazorWasm.Server.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.13" Condition="'$(Framework)' == 'net7.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" Condition="'$(Framework)' == 'net8.0'"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" Condition="'$(Framework)' == 'net8.0'"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

The Blazor WebAssembly .NET template for Auth0 supports .NET 7. As .NET 8 has been released, I added support for .NET 8.

### Testing

You can test this PR by locally installing the template and creating a project for both .NET 7 and .NET 8. Run and test the application. There is no automated testing available.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
