### PR TITLE
Fix missing dotnet runtime version for CLI Wrapper

### DIFF
--- a/cli-wrapper/cli-wrapper.csproj
+++ b/cli-wrapper/cli-wrapper.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>CliWrapper</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes the missing dotnet runtime version for CLI Wrapper as pointed out in #24
The fix is based on [controlling the roll-forward behavior](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior).

Close #24 