### PR TITLE
Fix registration script deletion bug

### DIFF
--- a/cli-wrapper/CliWrapper.cs
+++ b/cli-wrapper/CliWrapper.cs
@@ -123,14 +123,12 @@ public class CliWrapper
   public async Task RemoveRegistrationFolder()
   {
     string registrationFolderPath = $@"{Path.Combine(System.AppContext.BaseDirectory)}";
-    string registrationParentFolderPath = Directory.GetParent(registrationFolderPath.TrimEnd(Path.DirectorySeparatorChar)).FullName;
-    string registeringScriptPath = Path.Combine(registrationParentFolderPath, "register-with-auth0.cmd");
 
     Displayer.DisplayVerbose($@"About to remove the folder {registrationFolderPath}");
 
-    Displayer.DisplayVerbose($@"Moving the registering script file {registeringScriptPath}");
+    Displayer.DisplayVerbose($@"Moving the registering script file {configData.RegistrationScriptFile}");
     try {
-      File.Move(registeringScriptPath, Path.Combine(registrationFolderPath, "register-with-auth0.cmd"));
+      File.Move(Path.Combine(registrationFolderPath, configData.RegistrationScriptFile), Path.Combine(registrationFolderPath, "register-with-auth0.cmd"));
     } catch (Exception ex)
     {
       Displayer.DisplayErrorVerbose(ex.Message);

--- a/cli-wrapper/ConfigData.cs
+++ b/cli-wrapper/ConfigData.cs
@@ -6,6 +6,7 @@
   public string? Callbacks { get; set; }
   public string? LogoutUrls { get; set; }
   public string[]? AppSettingsFiles {get; set;}
+  public string? RegistrationScriptFile { get; set; }
 
   public bool Verbose {get; set;}
 }

--- a/cli-wrapper/README.md
+++ b/cli-wrapper/README.md
@@ -22,6 +22,7 @@ In order to enable a template to automatic registration via the CLI Wrapper, app
     "Callbacks": "https://localhost:5001/callback",
     "LogoutUrls": "https://localhost:5001/",
     "AppSettingsFiles": ["./appsettings.json"],
+    "RegistrationScriptFile": "../register-with-auth0.cmd",
     "Verbose": false
   }
   ```
@@ -33,6 +34,7 @@ In order to enable a template to automatic registration via the CLI Wrapper, app
   - `AppType` must contain the specific application type for the current project (see [type flag](https://auth0.github.io/auth0-cli/auth0_apps_create.html#flags) required by the `auth0 apps create` command of the Auth0 CLI). Its value is `api` for API templates.
   - `Callbacks` and `LogoutUrls` must use the same ports as in the templates (see `Properties/launchSettings.json`). Set these properties to empty strings for API templates.
   - `AppSettingsFiles` must point to the project's configuration files to update after registration
+  - `RegistrationScriptFile` is the relative path of the script `register-with-auth0.cmd` with respect to the `registration` folder . This path is used during the registration folder removal. Make sure it matches the actual file location.
   - `Verbose` is a boolean setting that enables a verbose onscreen log for diagnostic purposes.
 
 - Add the following `postAction` in the `template.config` file of the template:

--- a/templates/Auth0.BlazorServer/registration/config.json
+++ b/templates/Auth0.BlazorServer/registration/config.json
@@ -5,5 +5,6 @@
   "Callbacks": "https://localhost:5001/callback",
   "LogoutUrls": "https://localhost:5001/",
   "AppSettingsFiles": ["./appsettings.json"],
+  "RegistrationScriptFile": "../register-with-auth0.cmd",
   "Verbose": false
 }

--- a/templates/Auth0.BlazorWebApp/Auth0BlazorWebApp/registration/config.json
+++ b/templates/Auth0.BlazorWebApp/Auth0BlazorWebApp/registration/config.json
@@ -5,5 +5,6 @@
     "Callbacks": "https://localhost:5001/callback",
     "LogoutUrls": "https://localhost:5001/",
     "AppSettingsFiles": ["./Auth0BlazorWebApp/appsettings.json"],
+    "RegistrationScriptFile": "../../register-with-auth0.cmd",
     "Verbose": false
   }

--- a/templates/Auth0.BlazorWebAssembly/Client/registration/config.json
+++ b/templates/Auth0.BlazorWebAssembly/Client/registration/config.json
@@ -5,5 +5,6 @@
   "Callbacks": "https://localhost:5001/authentication/login-callback",
   "LogoutUrls": "https://localhost:5001",
   "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"],
+  "RegistrationScriptFile": "../../register-with-auth0.cmd",
   "Verbose": false
 }

--- a/templates/Auth0.BlazorWebAssembly/Server/registration/config.json
+++ b/templates/Auth0.BlazorWebAssembly/Server/registration/config.json
@@ -5,5 +5,6 @@
   "Callbacks": "",
   "LogoutUrls": "",
   "AppSettingsFiles": ["./Client//wwwroot/appsettings.json", "./Server/appsettings.json"],
+  "RegistrationScriptFile": "../../register-with-auth0.cmd",
   "Verbose": false
 }

--- a/templates/Auth0.Maui/registration/config.json
+++ b/templates/Auth0.Maui/registration/config.json
@@ -5,5 +5,6 @@
     "Callbacks": "myapp://callback/",
     "LogoutUrls": "myapp://callback/",
     "AppSettingsFiles": ["./MauiProgram.cs"],
+    "RegistrationScriptFile": "../register-with-auth0.cmd",
     "Verbose": false
   }

--- a/templates/Auth0.MinimalWebAPI/registration/config.json
+++ b/templates/Auth0.MinimalWebAPI/registration/config.json
@@ -4,5 +4,7 @@
   "AppType": "api",
   "Callbacks": "",
   "LogoutUrls": "",
-  "AppSettingsFiles": ["./appsettings.json"]
+  "AppSettingsFiles": ["./appsettings.json"],
+  "RegistrationScriptFile": "../register-with-auth0.cmd",
+  "Verbose": false
 }

--- a/templates/Auth0.Mvc/registration/config.json
+++ b/templates/Auth0.Mvc/registration/config.json
@@ -5,5 +5,6 @@
   "Callbacks": "https://localhost:5001/callback",
   "LogoutUrls": "https://localhost:5001/",
   "AppSettingsFiles": ["./appsettings.json"],
+  "RegistrationScriptFile": "../register-with-auth0.cmd",
   "Verbose": false
 }

--- a/templates/Auth0.WebAPI/registration/config.json
+++ b/templates/Auth0.WebAPI/registration/config.json
@@ -5,5 +5,6 @@
   "Callbacks": "",
   "LogoutUrls": "",
   "AppSettingsFiles": ["./appsettings.json"],
+  "RegistrationScriptFile": "../register-with-auth0.cmd",
   "Verbose": false
 }


### PR DESCRIPTION
This PR fixes a bug that prevented the script `register-with-auth0.cmd` script from being removed after registration in the Blazor Web App and Blazor Wasm templates