### PR TITLE
Add warning message to the registration step

### DIFF
--- a/cli-wrapper/Program.cs
+++ b/cli-wrapper/Program.cs
@@ -5,6 +5,10 @@
 if (await cliWrapper.IsAuth0CliInstalled())
 {
   Console.WriteLine("Auth0 CLI is installed.");
+  Console.WriteLine("Before starting the registration step, make sure you are logged in to your Auth0 tenant through Auth0 CLI.");
+  Console.WriteLine("If you are not logged in, open a new terminal window and run `auth0 login`, then come back here to continue the registration step.");
+  Console.WriteLine("If you are already logged in, press any key to continue...");
+  Console.ReadKey();
 
   var registrationData = await cliWrapper.Register();
 


### PR DESCRIPTION
### Description

This PR mitigates the effects of the bug #40 by simply warning the user to log in with the Auth0 CLI before starting the registration process.

### References

#40 