### PR TITLE
Fix returnUrl issue

### DIFF
--- a/templates/Auth0.BlazorServer/Pages/Login.cshtml.cs
+++ b/templates/Auth0.BlazorServer/Pages/Login.cshtml.cs
@@ -6,10 +6,10 @@ namespace Auth0BlazorServer.Pages;
 
 public class LoginModel : PageModel
 {
-  public async Task OnGet(string redirectUri)
+  public async Task OnGet(string returnUrl = "/")
   {
     var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
-        .WithRedirectUri(redirectUri)
+        .WithRedirectUri(returnUrl)
         .Build();
 
     await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);

--- a/templates/Auth0.BlazorServer/Shared/AccessControl.razor
+++ b/templates/Auth0.BlazorServer/Shared/AccessControl.razor
@@ -3,6 +3,6 @@
         <a href="logout">Log out</a>
     </Authorized>
     <NotAuthorized>
-        <a href="login?redirectUri=/">Log in</a>
+        <a href="login">Log in</a>
     </NotAuthorized>
 </AuthorizeView>

--- a/templates/Auth0.BlazorWebApp/version8/Auth0BlazorWebApp/Components/Login.razor
+++ b/templates/Auth0.BlazorWebApp/version8/Auth0BlazorWebApp/Components/Login.razor
@@ -3,6 +3,6 @@
         <a href="Account/Logout">Log out</a>
     </Authorized>
     <NotAuthorized>
-        <a href="Account/Login?redirectUri=/">Log in</a>
+        <a href="Account/Login">Log in</a>
     </NotAuthorized>
 </AuthorizeView>

--- a/templates/Auth0.BlazorWebApp/version8/Auth0BlazorWebApp/Program.cs
+++ b/templates/Auth0.BlazorWebApp/version8/Auth0BlazorWebApp/Program.cs
@@ -42,19 +42,19 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-app.MapGet("/account/login", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/account/login", async (HttpContext httpContext, string returnUrl = "/") =>
 {
   var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri(returnUrl)
           .Build();
 
   await httpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
 });
 
-app.MapGet("/account/logout", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/account/logout", async (HttpContext httpContext) =>
 {
   var authenticationProperties = new LogoutAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri("/")
           .Build();
 
   await httpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);

--- a/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp/Components/Login.razor
+++ b/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp/Components/Login.razor
@@ -3,6 +3,6 @@
         <a href="Account/Logout">Log out</a>
     </Authorized>
     <NotAuthorized>
-        <a href="Account/Login?redirectUri=/">Log in</a>
+        <a href="Account/Login">Log in</a>
     </NotAuthorized>
 </AuthorizeView>

--- a/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp/Program.cs
+++ b/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp/Program.cs
@@ -41,19 +41,19 @@ app.UseHttpsRedirection();
 
 app.UseAntiforgery();
 
-app.MapGet("/account/login", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/account/login", async (HttpContext httpContext, string returnUrl = "/") =>
 {
   var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri(returnUrl)
           .Build();
 
   await httpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
 });
 
-app.MapGet("/account/logout", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/account/logout", async (HttpContext httpContext) =>
 {
   var authenticationProperties = new LogoutAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri("/")
           .Build();
 
   await httpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);


### PR DESCRIPTION
### Description

This PR uses the builtin ASP.NET Core `returnUrl` parameter in Blazor Web App template to go back to the calling page after login

### References

Closes #36 
