### PR TITLE
Convert to .NET Standard 2.0

### DIFF
--- a/Auth0Templates.csproj
+++ b/Auth0Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.3.1</PackageVersion>
+    <PackageVersion>2.4.0</PackageVersion>
     <PackageId>Auth0.Templates</PackageId>
     <Title>Auth0 Templates for .NET</Title>
     <Authors>Auth0</Authors>
@@ -33,7 +33,7 @@
 
     <Target Name="AddCliWrapper" AfterTargets="BeforeBuild">
       <ItemGroup>
-        <CliWrapperFiles Include="cli-wrapper\bin\Release\net7.0\publish\cli-wrapper.*;"/>
+        <CliWrapperFiles Include="cli-wrapper\bin\Release\netstandard2.0\publish\cli-wrapper.*;"/>
       </ItemGroup>
 
       <Exec Command="dotnet publish cli-wrapper/cli-wrapper.csproj -c Release -p:UseAppHost=false" />

--- a/cli-wrapper/CliWrapper.cs
+++ b/cli-wrapper/CliWrapper.cs
@@ -1,6 +1,9 @@
-﻿using System.Diagnostics;
-using System.Text.Json;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 public class CliWrapper
 {
@@ -11,7 +14,7 @@ public class CliWrapper
     string templateConfigurationFilePath = $@"{Path.Combine(System.AppContext.BaseDirectory, "config.json")}";
     string text = File.ReadAllText(templateConfigurationFilePath);
 
-    configData = JsonSerializer.Deserialize<ConfigData>(text);
+    configData = JsonConvert.DeserializeObject<ConfigData>(text);
 
     Displayer.Verbose = configData.Verbose;
   }
@@ -23,7 +26,7 @@ public class CliWrapper
     try
     {
       string cmdOutput = await RunCommand("auth0", "--version");
-      string currentCliVersionString = cmdOutput.Split(" ")[2];
+      string currentCliVersionString = cmdOutput.Split(new[] { ' ' })[2];
       Version currentCliVersion = new Version(currentCliVersionString);
 
       Displayer.DisplayVerbose($@"Auth0 CLI version: {currentCliVersionString}");
@@ -63,7 +66,7 @@ public class CliWrapper
 
     try
     {
-      registrationData = JsonSerializer.Deserialize<RegistrationData>(registrationOutputText)!;
+      registrationData = JsonConvert.DeserializeObject<RegistrationData>(registrationOutputText);
     }
     catch (Exception ex)
     {
@@ -110,63 +113,70 @@ public class CliWrapper
     }
   }
 
-  public async Task RemoveRegistrationFolder()
+  public Task RemoveRegistrationFolder()
   {
-    string registrationFolderPath = $@"{Path.Combine(System.AppContext.BaseDirectory)}";
+    return Task.Run(() => {
+      string registrationFolderPath = $@"{Path.Combine(System.AppContext.BaseDirectory)}";
 
-    Displayer.DisplayVerbose($@"About to remove the folder {registrationFolderPath}");
+      Displayer.DisplayVerbose($@"About to remove the folder {registrationFolderPath}");
 
-    if (Environment.OSVersion.Platform == PlatformID.Unix ||
-          Environment.OSVersion.Platform == PlatformID.MacOSX)
-    {
-      Directory.Delete(registrationFolderPath, true);
-    } else
-    {
-      // Hack to bypass executable lock in Windows (https://andreasrohner.at/posts/Programming/C%23/A-platform-independent-way-for-a-C%23-program-to-update-itself/)
-      var delScriptName = Path.Combine(registrationFolderPath, "selfdel.bat");
+      if (Environment.OSVersion.Platform == PlatformID.Unix ||
+            Environment.OSVersion.Platform == PlatformID.MacOSX)
+      {
+        Directory.Delete(registrationFolderPath, true);
+      } 
+      else
+      {
+        // Hack to bypass executable lock in Windows (https://andreasrohner.at/posts/Programming/C%23/A-platform-independent-way-for-a-C%23-program-to-update-itself/)
+        var delScriptName = Path.Combine(registrationFolderPath, "selfdel.bat");
 
-      using (var batFile = new StreamWriter (delScriptName)) {
-        batFile.WriteLine ("@ECHO OFF");
-        batFile.WriteLine ("TIMEOUT /t 5 /nobreak > NUL");
-        batFile.WriteLine ($@"RMDIR /S /Q {registrationFolderPath}");
+        using (var batFile = new StreamWriter(delScriptName)) 
+        {
+          batFile.WriteLine("@ECHO OFF");
+          batFile.WriteLine("TIMEOUT /t 5 /nobreak > NUL");
+          batFile.WriteLine($@"RMDIR /S /Q {registrationFolderPath}");
+        }
+
+        RunCommandAndForget(delScriptName, "");
       }
-
-      RunCommandAndForget(delScriptName, "");
-    }
+    });
   }
 
-  private async Task<string> RunCommand(string command, string args)
+  private Task<string> RunCommand(string command, string args)
   {
-    ProcessStartInfo startInfo = new()
-    {
-      FileName = command,
-      Arguments = args,
-      CreateNoWindow = true,
-      RedirectStandardOutput = true,
-      RedirectStandardError = true,
-    };
+    return Task.Run(() => {
+      ProcessStartInfo startInfo = new ProcessStartInfo
+      {
+        FileName = command,
+        Arguments = args,
+        CreateNoWindow = true,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+      };
 
-    Displayer.DisplayVerbose($@"About to run command: {command} {args}");
+      Displayer.DisplayVerbose($@"About to run command: {command} {args}");
 
-    var proc = Process.Start(startInfo);
-    ArgumentNullException.ThrowIfNull(proc);
-    string output = proc.StandardOutput.ReadToEnd();
-    string errorText = proc.StandardError.ReadToEnd();
-    await proc.WaitForExitAsync();
+      var proc = Process.Start(startInfo);
+      if (proc == null)
+          throw new InvalidOperationException("Failed to start process");
+      string output = proc.StandardOutput.ReadToEnd();
+      string errorText = proc.StandardError.ReadToEnd();
+      proc.WaitForExit();
 
-    if (!string.IsNullOrEmpty(errorText) && errorText.Contains("error"))
-    {
-      throw new Exception(errorText);
-    }
+      if (!string.IsNullOrEmpty(errorText) && errorText.Contains("error"))
+      {
+        throw new Exception(errorText);
+      }
 
-    Displayer.DisplayCommandOutput(output);
+      Displayer.DisplayCommandOutput(output);
 
-    return output;
+      return output;
+    });
   }
 
   private void RunCommandAndForget(string command, string args)
   {
-    ProcessStartInfo startInfo = new()
+    ProcessStartInfo startInfo = new ProcessStartInfo
     {
       FileName = command,
       Arguments = args,
@@ -219,7 +229,7 @@ public class CliWrapper
 
     try
     {
-      var registrationDataList = JsonSerializer.Deserialize<RegistrationData[]>(registrationDataListText)!;
+      var registrationDataList = JsonConvert.DeserializeObject<RegistrationData[]>(registrationDataListText);
 
       Displayer.DisplayVerbose($@"Found {registrationDataList.Length} registered APIs.");
 

--- a/cli-wrapper/ConfigData.cs
+++ b/cli-wrapper/ConfigData.cs
@@ -1,12 +1,12 @@
 ﻿public class ConfigData
 {
-  public string? AppName { get; set; }
-  public string? AppDescription { get; set; }
-  public string? AppType { get; set; }
-  public string? Callbacks { get; set; }
-  public string? LogoutUrls { get; set; }
-  public string[]? AppSettingsFiles {get; set;}
-  public string? RegistrationScriptFile { get; set; }
+  public string AppName { get; set; }
+  public string AppDescription { get; set; }
+  public string AppType { get; set; }
+  public string Callbacks { get; set; }
+  public string LogoutUrls { get; set; }
+  public string[] AppSettingsFiles {get; set;}
+  public string RegistrationScriptFile { get; set; }
 
   public bool Verbose {get; set;}
 }

--- a/cli-wrapper/Displayer.cs
+++ b/cli-wrapper/Displayer.cs
@@ -1,4 +1,6 @@
-﻿public static class Displayer
+﻿using System;
+
+public static class Displayer
 {
   public static bool Verbose { get; set; }
 

--- a/cli-wrapper/Program.cs
+++ b/cli-wrapper/Program.cs
@@ -1,24 +1,34 @@
-﻿var cliWrapper = new CliWrapper();
+﻿using System;
+using System.Threading.Tasks;
 
-//Displayer.Verbose = true;
-
-if (await cliWrapper.IsAuth0CliInstalled())
+public class Program
 {
-  Console.WriteLine("Auth0 CLI is installed.");
-  Console.WriteLine("Before starting the registration step, make sure you are logged in to your Auth0 tenant through Auth0 CLI.");
-  Console.WriteLine("If you are not logged in, open a new terminal window and run `auth0 login`, then come back here to continue the registration step.");
-  Console.WriteLine("If you are already logged in, press any key to continue...");
-  Console.ReadKey();
+    public static async Task Main(string[] args)
+    {
+        var cliWrapper = new CliWrapper();
 
-  var registrationData = await cliWrapper.Register();
+        //Displayer.Verbose = true;
 
-  Displayer.DisplayRegistrationData(registrationData);
-  
-  await cliWrapper.UpdateConfigFiles(registrationData);
-} else
-{
-  Console.WriteLine("Auth0 CLI is not installed or it's not the required version.");
-  Console.WriteLine("Please, install the Auth0 CLI ver. 1.0.1 or later (https://auth0.github.io/auth0-cli/).");
+        if (await cliWrapper.IsAuth0CliInstalled())
+        {
+            Console.WriteLine("Auth0 CLI is installed.");
+            Console.WriteLine("Before starting the registration step, make sure you are logged in to your Auth0 tenant through Auth0 CLI.");
+            Console.WriteLine("If you are not logged in, open a new terminal window and run `auth0 login`, then come back here to continue the registration step.");
+            Console.WriteLine("If you are already logged in, press any key to continue...");
+            Console.ReadKey();
+
+            var registrationData = await cliWrapper.Register();
+
+            Displayer.DisplayRegistrationData(registrationData);
+            
+            await cliWrapper.UpdateConfigFiles(registrationData);
+        }
+        else
+        {
+            Console.WriteLine("Auth0 CLI is not installed or it's not the required version.");
+            Console.WriteLine("Please, install the Auth0 CLI ver. 1.0.1 or later (https://auth0.github.io/auth0-cli/).");
+        }
+
+        await cliWrapper.RemoveRegistrationFolder();
+    }
 }
-
-await cliWrapper.RemoveRegistrationFolder();

--- a/cli-wrapper/RegistrationData.cs
+++ b/cli-wrapper/RegistrationData.cs
@@ -1,12 +1,27 @@
-﻿public record RegistrationData(
-  string name,
-  string client_id,
-  string identifier,
-  SigningKeys[] signing_keys
-);
+﻿public class RegistrationData
+{
+    public string name { get; set; }
+    public string client_id { get; set; }
+    public string identifier { get; set; }
+    public SigningKeys[] signing_keys { get; set; }
+
+    public RegistrationData(string name, string client_id, string identifier, SigningKeys[] signing_keys)
+    {
+        this.name = name;
+        this.client_id = client_id;
+        this.identifier = identifier;
+        this.signing_keys = signing_keys;
+    }
+}
 
 // missing current tenant (see https://github.com/auth0/auth0-cli/issues/773)
 
-public record SigningKeys(
-  string subject
-);
+public class SigningKeys
+{
+    public string subject { get; set; }
+
+    public SigningKeys(string subject)
+    {
+        this.subject = subject;
+    }
+}

--- a/cli-wrapper/cli-wrapper.csproj
+++ b/cli-wrapper/cli-wrapper.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>CliWrapper</RootNamespace>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <RollForward>Major</RollForward>
+    <LangVersion>7.3</LangVersion>
     <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="config.json">


### PR DESCRIPTION
### Description

This PR converts the CLI-Wrapper project from .NET 7.0 to .NET Standard 2.0 in order to platform and framework independent.

Here is a quick summary of the changes:

- Updated `cli-wrapper.csproj` to target .NET Standard 2.0 and added Newtonsoft.Json package
- Converted record types to regular classes in `RegistrationData.cs`
- Removed nullable annotations from `ConfigData.cs`
- Updated `Program.cs` to use proper class structure and added required `using` statements
- Modified `CliWrapper.cs` to:
    - Use `Newtonsoft.Json` instead of `System.Text.Json`
    - Fixed string splitting for older .NET versions
    - Updated process handling code to be compatible with .NET Standard 2.0
    - Wrapped synchronous process operations in `Task.Run`
    - Removed newer C# features not available in C# 7.3

### References

Closes #54 