### PR TITLE
Add #Windows directive to prevent compile issues on non-windows machines

### DIFF
--- a/templates/Auth0.Maui/version9/App.xaml.cs
+++ b/templates/Auth0.Maui/version9/App.xaml.cs
@@ -4,8 +4,10 @@ public partial class App : Application
 {
 	public App()
 	{
-		if (!Auth0.OidcClient.Platforms.Windows.Activator.Default.CheckRedirectionActivation())
-			InitializeComponent();
+		#if WINDOWS
+		if (Auth0.OidcClient.Platforms.Windows.Activator.Default.CheckRedirectionActivation())
+		    return;
+		#endif
 	}
 
 	protected override Window CreateWindow(IActivationState? activationState)


### PR DESCRIPTION
### Description

Adds a `#Windows` directive in code, to ensure the code compiles in non-windows machines as well.

### References
- Fixes an issue reported in [auth0-oidc-client-net](https://github.com/auth0/auth0-oidc-client-net/issues/371)

### Testing
- N / A 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
