### PR TITLE
Minor fixes

### DIFF
--- a/templates/Auth0.BlazorWebApp/version10/Auth0BlazorWebApp.Client/Pages/Counter.razor
+++ b/templates/Auth0.BlazorWebApp/version10/Auth0BlazorWebApp.Client/Pages/Counter.razor
@@ -1,4 +1,5 @@
 ﻿@page "/counter"
+@attribute [Authorize]
 @rendermode InteractiveAuto
 
 <PageTitle>Counter</PageTitle>

--- a/templates/Auth0.BlazorWebApp/version10/Auth0BlazorWebApp.Client/Pages/Counter.razor
+++ b/templates/Auth0.BlazorWebApp/version10/Auth0BlazorWebApp.Client/Pages/Counter.razor
@@ -6,12 +6,29 @@
 
 <h1>Counter</h1>
 
+<p>Hello @Username!</p>
 <p role="status">Current count: @currentCount</p>
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
 @code {
     private int currentCount = 0;
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? authenticationState { get; set; }
+
+    private string Username = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (authenticationState is not null)
+        {
+            var state = await authenticationState;
+
+            Username = state?.User?.Identity?.Name ?? string.Empty;
+        }
+        await base.OnInitializedAsync();
+    }
 
     private void IncrementCount()
     {

--- a/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp.Client/Pages/Counter.razor
+++ b/templates/Auth0.BlazorWebApp/version9/Auth0BlazorWebApp.Client/Pages/Counter.razor
@@ -4,12 +4,9 @@
 
 <PageTitle>Counter</PageTitle>
 
-<p>Hello @Username!</p>
-
 <h1>Counter</h1>
 
 <p>Hello @Username!</p>
-
 <p role="status">Current count: @currentCount</p>
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>

--- a/templates/Auth0.Maui/.template.config/template.json
+++ b/templates/Auth0.Maui/.template.config/template.json
@@ -86,8 +86,7 @@
           "condition": "(!autoregister)",
           "exclude": [ "registration/**/*" ]
         }
-      ],
-      "copyOnly": [ "registration/**/*" ]
+      ]
     }
   ],
   "postActions": [{

--- a/templates/Auth0.WebAPI/.template.config/template.json
+++ b/templates/Auth0.WebAPI/.template.config/template.json
@@ -245,8 +245,7 @@
             "condition": "(!autoregister)",
             "exclude": [ "registration/**/*" ]
         }
-      ],
-      "copyOnly": [ "registration/**/*" ]
+      ]
     },
     {
       "condition": "(!controllers) && (Framework == \"net10.0\")",
@@ -260,8 +259,7 @@
             "condition": "(!autoregister)",
             "exclude": [ "registration/**/*" ]
         }
-      ],
-      "copyOnly": [ "registration/**/*" ]
+      ]
     }
   ],
   "postActions": [{


### PR DESCRIPTION
This PR fixes the following issues:

- The flag `copyonly` in the MAUI and API templates for .NET 10 prevented from using the user-assigned application name while registering the application with Auth0
- Missing `Authorize` attribute in the counter component of the Blazor template for .NET 10
- Missing authentication state management in the counter component of the Blazor template for .NET 10